### PR TITLE
Added $hex command for testing hex colors

### DIFF
--- a/Kaguya/Kaguya/Discord/Commands/Reference/Hex.cs
+++ b/Kaguya/Kaguya/Discord/Commands/Reference/Hex.cs
@@ -1,0 +1,41 @@
+using Discord.Commands;
+using Kaguya.Internal.Attributes;
+using Kaguya.Internal.Enums;
+using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
+using System;
+
+namespace Kaguya.Discord.Commands.Reference
+{
+	[Module(CommandModule.Reference)]
+	[Group("hex")]
+	[Alias("hx")]
+	public class Hex : KaguyaBase<Hex>
+	{
+		private readonly ILogger<Hex> _logger;
+
+		public Hex(ILogger<Hex> logger) : base(logger)
+		{
+			_logger = logger;
+		}
+
+		[Command]
+		[Summary("Takes a hexadecimal color value and outputs an embed with that color.")]
+		[Remarks("<hex value>")]
+		public async Task HexTestCommand(string hex)
+		{
+			uint colorValue = Convert.ToUInt32(hex, 16);
+			uint maxValue = Convert.ToUInt32("FFFFFF", 16);
+
+			// If colorValue is FFFFFF, the color turns black, so we need to subtract one
+			if (colorValue == maxValue) --colorValue;
+
+			var embed = new KaguyaEmbedBuilder(colorValue)
+			{
+				Description = "Success!"
+			};
+
+			await SendEmbedAsync(embed);
+		}
+	}
+}

--- a/Kaguya/Kaguya/Discord/Commands/Reference/Hex.cs
+++ b/Kaguya/Kaguya/Discord/Commands/Reference/Hex.cs
@@ -9,7 +9,6 @@ namespace Kaguya.Discord.Commands.Reference
 {
 	[Module(CommandModule.Reference)]
 	[Group("hex")]
-	[Alias("hx")]
 	public class Hex : KaguyaBase<Hex>
 	{
 		private readonly ILogger<Hex> _logger;
@@ -22,17 +21,23 @@ namespace Kaguya.Discord.Commands.Reference
 		[Command]
 		[Summary("Takes a hexadecimal color value and outputs an embed with that color.")]
 		[Remarks("<hex value>")]
+		[Example("FFFFFF")]
+		[Example("0000FF")]
+		[Example("FF0000")]
 		public async Task HexTestCommand(string hex)
 		{
 			uint colorValue = Convert.ToUInt32(hex, 16);
 			uint maxValue = Convert.ToUInt32("FFFFFF", 16);
 
 			// If colorValue is FFFFFF, the color turns black, so we need to subtract one
-			if (colorValue == maxValue) --colorValue;
+			if (colorValue == maxValue)
+			{
+				colorValue--;
+			}
 
 			var embed = new KaguyaEmbedBuilder(colorValue)
 			{
-				Description = "Success!"
+				Description = "The color of this embed is what your hex looks like."
 			};
 
 			await SendEmbedAsync(embed);


### PR DESCRIPTION
The $hex command takes a hexadecimal color value and outputs an embed with that color.

$hex <hex value>

Can also be written as $hx

ex.:
$hex 0000FF -> outputs a blue embed
$hex FF0000 -> outputs a red embed
$hx 00FFFF -> outputs a cyan embed