### PR TITLE
Search message modified

### DIFF
--- a/Kaguya/Kaguya/Discord/Commands/Music/Play.cs
+++ b/Kaguya/Kaguya/Discord/Commands/Music/Play.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
@@ -60,9 +62,23 @@ namespace Kaguya.Discord.Commands.Music
             }
 
             LavaPlayer player = _lavaNode.GetPlayer(Context.Guild);
-            SearchResponse searchResponse = await _lavaNode.SearchYouTubeAsync(search);
+            SearchResponse searchResult;
+            try
+            {
+                searchResult = await _lavaNode.SearchYouTubeAsync(search);
+            }
+            catch (HttpRequestException e)
+            {
+                string error = "Lavalink is not connected. Please start lavalink in " + 
+                               Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), @"..\..\..\", "Lavalink.jar"));
+                _logger.LogError(e, error);
+                
+                await SendBasicErrorEmbedAsync(error);
 
-            var track = searchResponse.Tracks.FirstOrDefault();
+                return;
+            }
+
+            var track = searchResult.Tracks.FirstOrDefault();
 
             if (track == null)
             {

--- a/Kaguya/Kaguya/Discord/Commands/Music/Play.cs
+++ b/Kaguya/Kaguya/Discord/Commands/Music/Play.cs
@@ -69,11 +69,12 @@ namespace Kaguya.Discord.Commands.Music
             }
             catch (HttpRequestException e)
             {
-                string error = "Lavalink is not connected. Please start lavalink in " + 
-                               Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), @"..\..\..\", "Lavalink.jar"));
-                _logger.LogError(e, error);
+                string pvtError = "Lavalink is not connected. Please start lavalink in " + 
+                                  Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), @"..\..\..\", "Lavalink.jar"));
+                _logger.LogError(e, pvtError);
                 
-                await SendBasicErrorEmbedAsync(error);
+                await SendBasicErrorEmbedAsync("Failure, core dependency missing. Please check the " +
+                                               "console logs for more details.");
 
                 return;
             }

--- a/Kaguya/Kaguya/Discord/Commands/Music/Search.cs
+++ b/Kaguya/Kaguya/Discord/Commands/Music/Search.cs
@@ -64,11 +64,12 @@ namespace Kaguya.Discord.Commands.Music
             }
             catch (HttpRequestException e)
             {
-                string error = "Lavalink is not connected. Please start lavalink in " + 
+                string pvtError = "Lavalink is not connected. Please start lavalink in " + 
                                Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), @"..\..\..\", "Lavalink.jar"));
-                _logger.LogError(e, error);
+                _logger.LogError(e, pvtError);
                 
-                await SendBasicErrorEmbedAsync(error);
+                await SendBasicErrorEmbedAsync("Failure, core dependency missing. Please check the " +
+                                               "console logs for more details.");
 
                 return;
             }

--- a/Kaguya/Kaguya/Discord/Overrides/Extensions/KaguyaInteractivityExtensions.cs
+++ b/Kaguya/Kaguya/Discord/Overrides/Extensions/KaguyaInteractivityExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Qommon.Collections;
+
+namespace Kaguya.Discord.Overrides.Extensions
+{
+    internal static partial class KaguyaInteractivityExtensions
+    {
+        public static ReadOnlyCollection<T> AsReadOnlyCollection<T>(this IEnumerable<T> collection)
+            => new ReadOnlyCollection<T>(collection.ToArray());
+
+        public static ReadOnlyDictionary<TKey, TValue> AsReadOnlyDictionary<TKey, TValue>(this Dictionary<TKey, TValue> dictionary)
+            => new ReadOnlyDictionary<TKey, TValue>(dictionary);
+    }
+}

--- a/Kaguya/Kaguya/Discord/Overrides/KaguyaReactionSelection.cs
+++ b/Kaguya/Kaguya/Discord/Overrides/KaguyaReactionSelection.cs
@@ -1,0 +1,100 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Discord;
+using Discord.WebSocket;
+using Interactivity;
+using Interactivity.Selection;
+
+namespace Kaguya.Discord.Overrides
+{
+    /// <summary>
+    /// Represents the default implementation of <see cref="BaseReactionSelection{TValue}"/> which comes with a lot of options suitable for most users.
+    /// This class is immutable!
+    /// </summary>
+    /// <typeparam name="TValue">The type of the values to select from</typeparam>
+    public sealed class KaguyaReactionSelection<TValue> : BaseReactionSelection<TValue>
+    {
+        /// <summary>
+        /// Gets the items to select from.
+        /// </summary>
+        public IReadOnlyDictionary<IEmote, TValue> Selectables { get; }
+
+        /// <summary>
+        /// Gets the <see cref="Page"/> which is sent into the channel.
+        /// </summary>
+        public Page SelectionPage { get; }
+
+        /// <summary>
+        /// Gets the <see cref="Page"/> which will be shown on cancellation.
+        /// </summary>
+        public Page CancelledPage { get; }
+
+        /// <summary>
+        /// Gets the <see cref="Page"/> which will be shown on a timeout.
+        /// </summary>
+        public Page TimeoutedPage { get; }
+
+        /// <summary>
+        /// Gets whether the selection allows for cancellation.
+        /// </summary>
+        public bool AllowCancel { get; }
+
+        /// <summary>
+        /// Gets the emote used for cancelling.
+        /// Only works if <see cref="AllowCancel"/> is set to <see cref="true"/>.
+        /// </summary>
+        public IEmote CancelEmote { get; }
+
+        public KaguyaReactionSelection(IReadOnlyDictionary<IEmote, TValue> selectables, IReadOnlyCollection<SocketUser> users,
+            Page selectionPage, Page cancelledPage, Page timeoutedPage,
+            bool allowCancel, IEmote cancelEmote,
+            DeletionOptions deletion)
+            : base(users, deletion)
+        {
+            Selectables = selectables;
+            SelectionPage = selectionPage;
+            CancelledPage = cancelledPage;
+            TimeoutedPage = timeoutedPage;
+            AllowCancel = allowCancel;
+            CancelEmote = cancelEmote;
+        }
+
+        protected override bool ShouldProcess(SocketReaction reaction)
+            => (AllowCancel && reaction.Emote.Equals(CancelEmote)) || Selectables.ContainsKey(reaction.Emote);
+
+        protected override Optional<TValue> ParseValue(SocketReaction reaction)
+            => AllowCancel && reaction.Emote.Equals(CancelEmote)
+                ? Optional<TValue>.Unspecified
+                : Selectables[reaction.Emote];
+
+        protected override Task<IUserMessage> SendMessageAsync(IMessageChannel channel)
+            => channel.SendMessageAsync(text: SelectionPage.Text, embed: SelectionPage.Embed);
+
+        // This is this way so that the lib calling this does not modify our message.
+        protected override Task ModifyMessageAsync(IUserMessage message) => Task.CompletedTask;
+
+        protected override async Task InitializeMessageAsync(IUserMessage message)
+        {
+            await message.AddReactionsAsync(Selectables.Keys.ToArray());
+            if (AllowCancel)
+            {
+                await message.AddReactionAsync(CancelEmote);
+            }
+        }
+
+        protected override async Task CloseMessageAsync(IUserMessage message, InteractivityResult<TValue> result)
+        {
+            await message.RemoveAllReactionsAsync();
+
+            if (result.IsCancelled && CancelledPage != null)
+            {
+                await message.ModifyAsync(x => { x.Content = CancelledPage.Text; x.Embed = CancelledPage.Embed; });
+            }
+            if (result.IsTimeouted && TimeoutedPage != null)
+            {
+                await message.ModifyAsync(x => { x.Content = TimeoutedPage.Text; x.Embed = TimeoutedPage.Embed; });
+            }
+        }
+    }
+}

--- a/Kaguya/Kaguya/Discord/Overrides/KaguyaReactionSelectionBuilder.cs
+++ b/Kaguya/Kaguya/Discord/Overrides/KaguyaReactionSelectionBuilder.cs
@@ -1,0 +1,229 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Discord;
+using Discord.WebSocket;
+using Interactivity;
+using Interactivity.Extensions;
+using Interactivity.Selection;
+using Kaguya.Discord.Overrides.Extensions;
+
+namespace Kaguya.Discord.Overrides
+{
+    public sealed class KaguyaReactionSelectionBuilder<TValue> : BaseReactionSelectionBuilder<TValue>
+    {
+        /// <summary>
+        /// Gets or sets the items to select from.
+        /// </summary>
+        public Dictionary<IEmote, TValue> Selectables { get; set; } = new Dictionary<IEmote, TValue>();
+
+        /// <summary>
+        /// Gets or sets the function to convert the values into display text.
+        /// </summary>
+        public Func<TValue, string> StringConverter { get; set; } = x => x.ToString();
+
+        /// <summary>
+        /// Gets or sets the title of the selection.
+        /// </summary>
+        public string Title { get; set; } = "Select one of these:";
+
+        /// <summary>
+        /// Gets whether the selection allows for cancellation.
+        /// </summary>
+        public bool AllowCancel { get; set; } = true;
+
+        /// <summary>
+        /// Gets the emote used for cancelling.
+        /// Only works if <see cref="AllowCancel"/> is set to <see cref="true"/>.
+        /// </summary>
+        public IEmote CancelEmote { get; set; } = new Emoji("❌");
+
+        /// <summary>
+        /// Gets the <see cref="Page"/> which is sent into the channel.
+        /// </summary>
+        public PageBuilder SelectionPage { get; set; } = new PageBuilder().WithColor(Color.Blue);
+
+        /// <summary>
+        /// Gets the <see cref="Page"/> which will be shown on cancellation.
+        /// </summary>
+        public PageBuilder CancelledPage { get; set; } = null;
+
+        /// <summary>
+        /// Gets the <see cref="Page"/> which will be shown on a timeout.
+        /// </summary>
+        public PageBuilder TimeoutedPage { get; set; } = null;
+
+        /// <summary>
+        /// Gets or sets whether the selectionembed will be added by a default value visualizer.
+        /// </summary>
+        public bool EnableDefaultSelectionDescription { get; set; } = true;
+
+        /// <summary>
+        /// Creates a new <see cref="KaguyaReactionSelectionBuilder{TValue}"/> with default values.
+        /// </summary>
+        public KaguyaReactionSelectionBuilder() { }
+
+        /// <summary>
+        /// Creates a new <see cref="KaguyaReactionSelectionBuilder{TValue}"/> with default values.
+        /// </summary>
+        public static KaguyaReactionSelectionBuilder<TValue> Default => new KaguyaReactionSelectionBuilder<TValue>();
+
+        public override BaseReactionSelection<TValue> Build()
+        {
+            if (Selectables == null)
+            {
+                throw new ArgumentException(nameof(Selectables));
+            }
+            if (Selectables.Count == 0)
+            {
+                throw new InvalidOperationException("You need at least one selectable");
+            }
+            if (AllowCancel && Selectables.Keys.Contains(CancelEmote))
+            {
+                throw new InvalidOperationException("Found duplicate emotes! (Cancel Emote)");
+            }
+            if (Selectables.Distinct().Count() != Selectables.Count)
+            {
+                throw new InvalidOperationException("Found duplicate emotes!");
+            }
+            if (AllowCancel && CancelEmote == null)
+            {
+                throw new ArgumentNullException(nameof(CancelEmote));
+            }
+
+            if (EnableDefaultSelectionDescription == true)
+            {
+                var builder = new StringBuilder();
+
+                foreach (var selectable in Selectables)
+                {
+                    string option = StringConverter.Invoke(selectable.Value);
+                    builder.AppendLine($"{selectable.Key} - {option}");
+                }
+
+                SelectionPage.AddField(Title, builder.ToString());
+            }
+
+            return new KaguyaReactionSelection<TValue>(
+                Selectables.AsReadOnlyDictionary(),
+                Users?.AsReadOnlyCollection() ?? throw new ArgumentException(nameof(Users)),
+                SelectionPage?.Build() ?? throw new ArgumentNullException(nameof(SelectionPage)),
+                CancelledPage?.Build(),
+                TimeoutedPage?.Build(),
+                AllowCancel,
+                CancelEmote,
+                Deletion
+                );
+        }
+
+        /// <summary>
+        /// Sets the values to select from.
+        /// </summary>
+        public KaguyaReactionSelectionBuilder<TValue> WithSelectables<TKey>(IDictionary<TKey, TValue> selectables) where TKey : IEmote
+        {
+            Selectables = selectables.ToDictionary(x => x.Key as IEmote, x => x.Value);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the users who can interact with the selection.
+        /// </summary>
+        public KaguyaReactionSelectionBuilder<TValue> WithUsers(IEnumerable<SocketUser> users)
+        {
+            Users = users.ToList();
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the users who can interact with the selection.
+        /// </summary>
+        public KaguyaReactionSelectionBuilder<TValue> WithUsers(params SocketUser[] users)
+        {
+            Users = users.ToList();
+            return this;
+        }
+
+        /// <summary>
+        /// Sets what the selection should delete.
+        /// </summary>
+        public KaguyaReactionSelectionBuilder<TValue> WithDeletion(DeletionOptions deletion)
+        {
+            Deletion = deletion;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the selection embed of the selection.
+        /// </summary>
+        public KaguyaReactionSelectionBuilder<TValue> WithSelectionEmbed(PageBuilder selectionPage)
+        {
+            SelectionPage = selectionPage;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the embed which the selection embed gets modified to after the selection has been cancelled.
+        /// </summary>
+        public KaguyaReactionSelectionBuilder<TValue> WithCancelledEmbed(PageBuilder cancelledPage)
+        {
+            CancelledPage = cancelledPage;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the embed which the selection embed gets modified to after the selection has timed out.
+        /// </summary>
+        public KaguyaReactionSelectionBuilder<TValue> WithTimeoutedEmbed(PageBuilder timeoutedPage)
+        {
+            TimeoutedPage = timeoutedPage;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the function to convert the values into possibilites.
+        /// </summary>
+        public KaguyaReactionSelectionBuilder<TValue> WithStringConverter(Func<TValue, string> stringConverter)
+        {
+            StringConverter = stringConverter;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the title of the selection.
+        /// </summary>
+        public KaguyaReactionSelectionBuilder<TValue> WithTitle(string title)
+        {
+            Title = title;
+            return this;
+        }
+
+        /// <summary>
+        /// Gets whether the selection allows for cancellation.
+        /// </summary>
+        public KaguyaReactionSelectionBuilder<TValue> WithAllowCancel(bool allowCancel)
+        {
+            AllowCancel = allowCancel;
+            return this;
+        }
+
+        /// <summary>
+        /// Gets the emote used for cancelling.
+        /// Only works if <see cref="AllowCancel"/> is set to <see cref="true"/>.
+        /// </summary>
+        public KaguyaReactionSelectionBuilder<TValue> WithCancelEmote(IEmote cancelEmote)
+        {
+            CancelEmote = cancelEmote;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets whether the selectionembed will be added by a default value visualizer.
+        /// </summary>
+        public KaguyaReactionSelectionBuilder<TValue> WithEnableDefaultSelectionDescription(bool enableDefaultSelectionDescription)
+        {
+            EnableDefaultSelectionDescription = enableDefaultSelectionDescription;
+            return this;
+        }
+    }
+}

--- a/Kaguya/Kaguya/Discord/Overrides/KaguyaReactionSelectionBuilder.cs
+++ b/Kaguya/Kaguya/Discord/Overrides/KaguyaReactionSelectionBuilder.cs
@@ -59,16 +59,6 @@ namespace Kaguya.Discord.Overrides
         /// </summary>
         public bool EnableDefaultSelectionDescription { get; set; } = true;
 
-        /// <summary>
-        /// Creates a new <see cref="KaguyaReactionSelectionBuilder{TValue}"/> with default values.
-        /// </summary>
-        public KaguyaReactionSelectionBuilder() { }
-
-        /// <summary>
-        /// Creates a new <see cref="KaguyaReactionSelectionBuilder{TValue}"/> with default values.
-        /// </summary>
-        public static KaguyaReactionSelectionBuilder<TValue> Default => new KaguyaReactionSelectionBuilder<TValue>();
-
         public override BaseReactionSelection<TValue> Build()
         {
             if (Selectables == null)
@@ -92,7 +82,7 @@ namespace Kaguya.Discord.Overrides
                 throw new ArgumentNullException(nameof(CancelEmote));
             }
 
-            if (EnableDefaultSelectionDescription == true)
+            if (EnableDefaultSelectionDescription)
             {
                 var builder = new StringBuilder();
 

--- a/Kaguya/Kaguya/Internal/Music/AudioService.cs
+++ b/Kaguya/Kaguya/Internal/Music/AudioService.cs
@@ -55,6 +55,11 @@ namespace Kaguya.Internal.Music
                 return;
 
             LavaPlayer player = args.Player;
+
+            if (player == null) // Not sure when this could occur, but just to be safe...
+            {
+                return;
+            }
             
             bool canDequeue;
             LavaTrack queueable;

--- a/Kaguya/Kaguya/Internal/Music/AudioService.cs
+++ b/Kaguya/Kaguya/Internal/Music/AudioService.cs
@@ -23,18 +23,20 @@ namespace Kaguya.Internal.Music
             _disconnectTokens = new ConcurrentDictionary<ulong, CancellationTokenSource>();
         }
 
-        public async Task OnTrackStarted(TrackStartEventArgs arg)
+        public Task OnTrackStarted(TrackStartEventArgs arg)
         {
             _logger.LogInformation($"Track started for guild {arg.Player.VoiceChannel.Guild.Id}:\n\t" +
                                    $"[Name: {arg.Track.Title} | Duration: {arg.Track.Duration.HumanizeTraditionalReadable()}]");
             
             if (!_disconnectTokens.TryGetValue(arg.Player.VoiceChannel.Id, out CancellationTokenSource value))
-                return;
+                return Task.CompletedTask;
 
             if (value.IsCancellationRequested)
-                return;
+                return Task.CompletedTask;
 
             value.Cancel(true);
+
+            return Task.CompletedTask;
         }
 
         public async Task OnTrackEnded(TrackEndedEventArgs args)

--- a/Kaguya/Kaguya/Kaguya.csproj
+++ b/Kaguya/Kaguya/Kaguya.csproj
@@ -5,12 +5,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Discord.Net" Version="2.3.0-dev-20201223.7" />
-        <PackageReference Include="Discord.Net.Commands" Version="2.3.0-dev-20201223.7" />
-        <PackageReference Include="Discord.Net.Core" Version="2.3.0-dev-20201223.7" />
-        <PackageReference Include="Discord.Net.Rest" Version="2.3.0-dev-20201223.7" />
-        <PackageReference Include="Discord.Net.Webhook" Version="2.3.0-dev-20201223.7" />
-        <PackageReference Include="Discord.Net.WebSocket" Version="2.3.0-dev-20201223.7" />
+        <PackageReference Include="Discord.InteractivityAddon" Version="2.2.0-rc10" />
+        <PackageReference Include="Discord.Net" Version="2.3.0-dev-20210121.1" />
+        <PackageReference Include="Discord.Net.Commands" Version="2.3.0-dev-20210121.1" />
+        <PackageReference Include="Discord.Net.Core" Version="2.3.0-dev-20210121.1" />
+        <PackageReference Include="Discord.Net.Rest" Version="2.3.0-dev-20210121.1" />
+        <PackageReference Include="Discord.Net.Webhook" Version="2.3.0-dev-20210121.1" />
+        <PackageReference Include="Discord.Net.WebSocket" Version="2.3.0-dev-20210121.1" />
         <PackageReference Include="Humanizer" Version="2.8.26" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.1" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.1" />
@@ -35,12 +36,6 @@
 
     <ItemGroup>
       <Folder Include="Migrations" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Reference Include="Discord.InteractivityAddon, Version=2.2.0.0, Culture=neutral, PublicKeyToken=null">
-        <HintPath>..\..\References\Discord.InteractivityAddon.dll</HintPath>
-      </Reference>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This PR is to keep the lib `Discord.InteractivityAddon` from modifying a sent message that is interactable through reactions. In this case, it is song selection from $search.

This allows us to get rid of the reference to a (now outdated) fork of this lib and instead use the updated lib from nuget.