### PR TITLE
Version/4.3.1

### DIFF
--- a/Kaguya/Kaguya/Database/Model/KaguyaUser.cs
+++ b/Kaguya/Kaguya/Database/Model/KaguyaUser.cs
@@ -92,14 +92,14 @@ namespace Kaguya.Database.Model
 		/// <summary>
 		/// The user's level as returned by the experience formula.
 		/// </summary>
-		public double ExactGlobalExpLevel => ExperienceService.CalculateLevel(this.GlobalExp);
+		public decimal ExactGlobalExpLevel => ExperienceService.CalculateLevel(this.GlobalExp);
 
 		public int FishLevel => ExactFishLevel.ToFloor();
 
-		public double ExactFishLevel => ExperienceService.CalculateLevel(this.FishExp);
+		public decimal ExactFishLevel => ExperienceService.CalculateLevel(this.FishExp);
 
 		public int ExpToNextGlobalLevel => ExperienceService.CalculateExpFromLevel(GlobalExpLevel + 1) - this.GlobalExp;
-		public double PercentToNextLevel => ExperienceService.CalculatePercentToNextLevel(this.ExactGlobalExpLevel);
+		public decimal PercentToNextLevel => ExperienceService.CalculatePercentToNextLevel(this.ExactGlobalExpLevel);
 
 		// public IEnumerable<Praise> Praise => DatabaseQueries.GetAllForUserAsync<Praise>(UserId).Result;
 

--- a/Kaguya/Kaguya/Discord/Commands/Configuration/Log.cs
+++ b/Kaguya/Kaguya/Discord/Commands/Configuration/Log.cs
@@ -92,11 +92,12 @@ namespace Kaguya.Discord.Commands.Configuration
         }
         
         [Command("-set")]
-        [Summary("Sets a logtype to a text channel. All logs for the logtype will be " +
+        [Summary("Sets a logtype to a text channel. If no text channel is provided, the " +
+                 "channel the command is invoked from is selected. All logs for the logtype will be " +
                  "sent to the specified channel. You may also use the 'all' logtype to set " +
                  "everything to the same channel simultaneously.")]
-        [Remarks("<log type> <text channel>")]
-        public async Task LogSetCommand(string logType, SocketTextChannel textChannel)
+        [Remarks("<log type> [text channel]")]
+        public async Task LogSetCommand(string logType, SocketTextChannel textChannel = null)
         {
             await ModifyLogConfigAsync(logType, textChannel);
         }
@@ -112,6 +113,11 @@ namespace Kaguya.Discord.Commands.Configuration
 
         private async Task ModifyLogConfigAsync(string logType, SocketTextChannel textChannel)
         {
+            if (textChannel == null)
+            {
+                textChannel = Context.Channel as SocketTextChannel;
+            }
+            
             IList<PropertyInfo> properties = _logProperties;
             LogConfiguration logConfig = await _logConfigurationRepository.GetOrCreateAsync(Context.Guild.Id);
 

--- a/Kaguya/Kaguya/Discord/Commands/Exp/Profile.cs
+++ b/Kaguya/Kaguya/Discord/Commands/Exp/Profile.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Kaguya.Discord.Commands.Exp
 {
-    [Module(CommandModule.Games)]
+    [Module(CommandModule.Reference)]
     [Group("profile")]
     [Alias("p")]
     public class Profile : KaguyaBase<Profile>

--- a/Kaguya/Kaguya/Discord/Commands/Exp/Profile.cs
+++ b/Kaguya/Kaguya/Discord/Commands/Exp/Profile.cs
@@ -51,7 +51,7 @@ namespace Kaguya.Discord.Commands.Exp
             
             int fishCount = await _fishRepository.CountAllNonTrashAsync(user.UserId);
 
-            double percent = user.PercentToNextLevel;
+            decimal percent = user.PercentToNextLevel;
 
             IEmote diamondsEmote = _commonEmotes.KaguyaDiamondsAnimated;
             

--- a/Kaguya/Kaguya/Discord/Commands/Games/FishGame.cs
+++ b/Kaguya/Kaguya/Discord/Commands/Games/FishGame.cs
@@ -27,6 +27,8 @@ namespace Kaguya.Discord.Commands.Games
         private const int COINS = 75;
         private const int PREMIUM_COINS = 50;
         
+        private static readonly Random _random = new Random();
+        
         public FishGame(ILogger<FishGame> logger, KaguyaUserRepository kaguyaUserRepository, FishRepository fishRepository) : base(logger)
         {
             _logger = logger;
@@ -61,7 +63,13 @@ namespace Kaguya.Discord.Commands.Games
 	            return;
             }
 
-            FishRarity rarity = FishService.SelectRandomRarity();
+            decimal roll;
+            lock (_random)
+            {
+                roll = (decimal)_random.NextDouble();
+            }
+            
+            FishRarity rarity = FishService.SelectRarity(roll);
             FishType randomFish = FishService.SelectFish(rarity);
 
             (int coins, int exp) fishValue = FishService.GetFishValue(rarity);

--- a/Kaguya/Kaguya/Global.cs
+++ b/Kaguya/Kaguya/Global.cs
@@ -29,7 +29,7 @@ namespace Kaguya
         public const string DiscordTermsLink = "[Terms of Service](https://discord.com/terms)";
         public const string DiscordCommunityGuidelinesLink = "[Community Guidelines](https://discord.com/guidelines)";
 
-        public static readonly string Version = "4.3";
+        public static readonly string Version = "4.3.1";
 
         /// <summary>
         /// The number of shards currently logged into Discord.

--- a/Kaguya/Kaguya/Internal/PrimitiveExtensions/MathExtensions.cs
+++ b/Kaguya/Kaguya/Internal/PrimitiveExtensions/MathExtensions.cs
@@ -5,6 +5,7 @@ namespace Kaguya.Internal.PrimitiveExtensions
     public static class MathExtensions
     {
         public static int ToFloor(this double d) => (int) Math.Floor(d);
+        public static int ToFloor(this decimal d) => (int) Math.Floor(d);
         /// <summary>
         /// Formats the <see cref="num"/> into a format as follows:
         ///

--- a/Kaguya/Kaguya/Internal/Services/ExperienceService.cs
+++ b/Kaguya/Kaguya/Internal/Services/ExperienceService.cs
@@ -212,7 +212,9 @@ namespace Kaguya.Internal.Services
         public static double CalculateLevel(int exp)
         {
             if (exp < 64)
+            {
                 return 0;
+            }
 	        
             return Math.Sqrt((exp / 8) - 7);
         }
@@ -232,8 +234,7 @@ namespace Kaguya.Internal.Services
         /// <returns></returns>
         public static double CalculatePercentToNextLevel(double level) {
             double percentThrough = level - Math.Truncate(level);
-            double percentLeft = 1.0 - percentThrough;
-            return percentLeft * 100.0;
+            return percentThrough * 100.0;
         }
     }
 }

--- a/Kaguya/Kaguya/Internal/Services/ExperienceService.cs
+++ b/Kaguya/Kaguya/Internal/Services/ExperienceService.cs
@@ -209,14 +209,13 @@ namespace Kaguya.Internal.Services
             return CalculateLevel(oldExp).ToFloor() < CalculateLevel(newExp).ToFloor();
         }
         
-        public static double CalculateLevel(int exp)
+        public static decimal CalculateLevel(int exp)
         {
             if (exp < 64)
             {
                 return 0;
             }
-	        
-            return Math.Sqrt((exp / 8) - 7);
+            return (decimal)Math.Sqrt((exp / 8) - 7);
         }
 
         public static int CalculateExpFromLevel(double level)
@@ -232,9 +231,9 @@ namespace Kaguya.Internal.Services
         /// </summary>
         /// <param name="level"></param>
         /// <returns></returns>
-        public static double CalculatePercentToNextLevel(double level) {
-            double percentThrough = level - Math.Truncate(level);
-            return percentThrough * 100.0;
+        public static decimal CalculatePercentToNextLevel(decimal level) {
+            decimal percentThrough = level - Math.Truncate(level);
+            return percentThrough * 100.0M;
         }
     }
 }

--- a/Kaguya/Kaguya/Internal/Services/FishService.cs
+++ b/Kaguya/Kaguya/Internal/Services/FishService.cs
@@ -54,6 +54,16 @@ namespace Kaguya.Internal.Services
 	
 	public class FishService
 	{
+		// 110 / 200 chance to lose all coins gambled.
+		// 90 / 200 chance to profit.
+		// Expected value (using point values below): 74.3
+		public static readonly (decimal rangeMin, decimal rangeMax) RangeLegendary = (0.995M, 1M);    // 1 / 200 chance
+		public static readonly (decimal rangeMin, decimal rangeMax) RangeUltraRare = (0.98M, 0.994M); // 4 / 200 chance
+		public static readonly (decimal rangeMin, decimal rangeMax) RangeRare = (0.85M, 0.97M);       // 26 / 200 chance
+		public static readonly (decimal rangeMin, decimal rangeMax) RangeUncommon = (0.55M, 0.84M);   // 60 / 200 chance
+		public static readonly (decimal rangeMin, decimal rangeMax) RangeCommon = (0.30M, 0.54M);     // 50 / 200 chance
+		public static readonly (decimal rangeMin, decimal rangeMax) RangeTrash = (0.0M, 0.29M);     // 60 / 200 chance
+		
 		private static readonly Random _random = new Random();
 		
 		public static readonly Dictionary<FishType, FishRarity> FishMap = new Dictionary<FishType, FishRarity>
@@ -101,52 +111,36 @@ namespace Kaguya.Internal.Services
 		private static KeyValuePair<FishType, FishRarity>[] CommonFish => FishMap.Where(x => x.Value == FishRarity.Common).ToArray(); 
 		private static KeyValuePair<FishType, FishRarity>[] TrashFish => FishMap.Where(x => x.Value == FishRarity.Trash).ToArray(); 
 
-		public static FishRarity SelectRandomRarity()
+		public static FishRarity SelectRarity(decimal roll)
 		{
-			// 110 / 200 chance to lose all coins gambled.
-			// 90 / 200 chance to profit.
-			// Expected value (using point values below): 74.3
-			var rangeLegendary = (0.9995, 1); // 1 / 200 chance
-			var rangeUltraRare = (0.98, 0.99995); // 4 / 200 chance
-			var rangeRare = (0.85, 0.98); // 26 / 200 chance
-			var rangeUncommon = (0.55, 0.85); // 60 / 200 chance
-			var rangeCommon = (0.30, 0.55); // 50 / 200 chance
-			var rangeTrash = (0.0, 0.30); // 60 / 200 chance
-			
-			double roll;
-			lock (_random)
+			if (IsBetween(roll, RangeLegendary))
 			{
-				roll = _random.NextDouble();
-			}
-
-			if (IsBetween(roll, rangeTrash))
-			{
-				return FishRarity.Trash;
+				return FishRarity.Legendary;
 			}
 			
-			if (IsBetween(roll, rangeCommon))
-			{
-				return FishRarity.Common;
-			}
-
-			if (IsBetween(roll, rangeUncommon))
-			{
-				return FishRarity.Uncommon;
-			}
-
-			if (IsBetween(roll, rangeRare))
-			{
-				return FishRarity.Rare;
-			}
-
-			if (IsBetween(roll, rangeUltraRare))
+			if (IsBetween(roll, RangeUltraRare))
 			{
 				return FishRarity.UltraRare;
 			}
-
-			if (IsBetween(roll, rangeLegendary))
+			
+			if (IsBetween(roll, RangeRare))
 			{
-				return FishRarity.Legendary;
+				return FishRarity.Rare;
+			}
+			
+			if (IsBetween(roll, RangeUncommon))
+			{
+				return FishRarity.Uncommon;
+			}
+			
+			if (IsBetween(roll, RangeCommon))
+			{
+				return FishRarity.Common;
+			}
+			
+			if (IsBetween(roll, RangeTrash))
+			{
+				return FishRarity.Trash;
 			}
 
 			throw new Exception($"No valid FishRarity could be found for the roll {roll}.");
@@ -192,7 +186,7 @@ namespace Kaguya.Internal.Services
 			};
 		}
 
-		private static bool IsBetween(double num, (double min, double max) range)
+		private static bool IsBetween(decimal num, (decimal min, decimal max) range)
 		{
 			return range.min <= num && num <= range.max;
 		}

--- a/Kaguya/Kaguya/Internal/Services/GreetingService.cs
+++ b/Kaguya/Kaguya/Internal/Services/GreetingService.cs
@@ -33,6 +33,12 @@ namespace Kaguya.Internal.Services
                 var kaguyaServerRepository = scope.ServiceProvider.GetRequiredService<KaguyaServerRepository>();
                 
                 KaguyaServer server = await kaguyaServerRepository.GetOrCreateAsync(user.Guild.Id);
+                
+                if (String.IsNullOrWhiteSpace(server.CustomGreeting))
+                {
+                    return;
+                }
+                
                 SocketTextChannel channel = user.Guild.GetTextChannel(server.CustomGreetingTextChannelId.GetValueOrDefault());
            
                 if (channel == null && server.CustomGreetingTextChannelId != null)
@@ -45,7 +51,7 @@ namespace Kaguya.Internal.Services
 
                     return;
                 }
-
+                
                 string parsedMessage = ParseGreetingString(server.CustomGreeting, user);
 
                 try

--- a/Kaguya/KaguyaTests/TestExperience.cs
+++ b/Kaguya/KaguyaTests/TestExperience.cs
@@ -1,27 +1,42 @@
 using System;
 using Kaguya.Internal.Services;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace KaguyaTests
 {
     public class TextExperienceService
     {
+        private readonly ITestOutputHelper _testOutputHelper;
+        public TextExperienceService(ITestOutputHelper testOutputHelper) { _testOutputHelper = testOutputHelper; }
+
         // Math.Sqrt((exp / 8) - 7) is the formula the service is tested against for exp.
         [Theory]
         [InlineData(64, 1)]
         [InlineData(257586, 179.419201871)]
-        public void TestLevelCalculation(int exp, double level)
+        public void TestLevelCalculation(int exp, decimal level)
         {
-            double difference = Math.Abs(level * .00001);
-            Assert.True(Math.Abs(ExperienceService.CalculateLevel(exp) - level) <= difference);
+            Assert.True(ExperienceService.CalculateLevel(exp) - level == 0.0M);
         }
 
         [Theory]
         [InlineData(257586, 179.41641508)]
-        public void FailLevelCalculation(int exp, double level)
+        public void FailLevelCalculation(int exp, decimal level)
         {
-            double difference = Math.Abs(level * .00001);
-            Assert.False(Math.Abs(ExperienceService.CalculateLevel(exp) - level) <= difference);
+            Assert.False(ExperienceService.CalculateLevel(exp) - level == 0.0M);
+        }
+
+        [Theory]
+        [InlineData(1.54, 54)]
+        [InlineData(1000.54, 54)]
+        [InlineData(0.01, 1)]
+        [InlineData(100.999, 99.9)]
+        [InlineData(1.5, 50)]
+        public void TestPercentToNextLevelCalculation(decimal level, decimal check)
+        {
+            decimal progress = ExperienceService.CalculatePercentToNextLevel(level);
+            _testOutputHelper.WriteLine($"Level: {level} | Progress: {progress}%");
+            Assert.True(progress == check);
         }
     }
 }

--- a/Kaguya/KaguyaTests/TestExperience.cs
+++ b/Kaguya/KaguyaTests/TestExperience.cs
@@ -32,6 +32,8 @@ namespace KaguyaTests
         [InlineData(0.01, 1)]
         [InlineData(100.999, 99.9)]
         [InlineData(1.5, 50)]
+        [InlineData(1.00, 0.00)]
+        [InlineData(1.9999999999999, 99.99999999999)]
         public void TestPercentToNextLevelCalculation(decimal level, decimal check)
         {
             decimal progress = ExperienceService.CalculatePercentToNextLevel(level);

--- a/Kaguya/KaguyaTests/TestFish.cs
+++ b/Kaguya/KaguyaTests/TestFish.cs
@@ -1,0 +1,32 @@
+using Kaguya.Internal.Services;
+using Xunit;
+
+namespace KaguyaTests
+{
+    public class TestFish
+    {
+        [Theory]
+        [InlineData(1.00, FishRarity.Legendary)]
+        [InlineData(0.994, FishRarity.UltraRare)]
+        [InlineData(0.97, FishRarity.Rare)]
+        [InlineData(0.84, FishRarity.Uncommon)]
+        [InlineData(0.54, FishRarity.Common)]
+        [InlineData(0.29, FishRarity.Trash)]
+        public void TestFishRarityUpperLimits(decimal roll, FishRarity rarity)
+        {
+            Assert.True(FishService.SelectRarity(roll) == rarity);
+        }
+        
+        [Theory]
+        [InlineData(0.995, FishRarity.Legendary)]
+        [InlineData(0.98, FishRarity.UltraRare)]
+        [InlineData(0.85, FishRarity.Rare)]
+        [InlineData(0.55, FishRarity.Uncommon)]
+        [InlineData(0.30, FishRarity.Common)]
+        [InlineData(0.00, FishRarity.Trash)]
+        public void TestFishRarityLowerLimits(decimal roll, FishRarity rarity)
+        {
+            Assert.True(FishService.SelectRarity(roll) == rarity);
+        }
+    }
+}


### PR DESCRIPTION
Version 4.3.1
+ Fixed bug with the fish service where the Legendary fish were much more hard to catch than normal.
+ Moved $profile back into the reference command group
+ `$log -set` no longer requires a text channel parameter. It is optional. If not specified, the text channel the command is invoked from will be used for the log channel.
+ Fixed % to next level being inaccurate